### PR TITLE
docs: migrate instructions from notion to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 # Wiz Buildkite Plugin
 
-Scans your infrastructure-as-code files or docker images for security vulnerabilities using wiz.io.
+Scans your infrastructure-as-code Cloudformation stacks or docker images for security vulnerabilities using [wiz](https://www.wiz.io/)
 
-## Example
+## Examples
 
-Add the following to your `pipeline.yml`, the build step must export artifacts to `cdk/*.template.json` that can either be CloudFormation files or be automatically generated via `cdk synth`:
+### Docker Scanning
+
+Add the following to your `pipeline.yml`, the plugin will pull the image, scan it using wiz and create a buildkite annotation with the results.
 
 ```yml
 steps:
@@ -17,13 +19,49 @@ steps:
           image-address: "<image-address-to-pull-and-scan>"
 ```
 
-If you are using the [AWS Assume Role Plugin](https://github.com/cultureamp/aws-assume-role-buildkite-plugin), you might have trouble getting your secret key from `aws secretsmanager` if the role you assumed doesn't have the right access rights. To restore your role, you can use the [AWS Restore Role Buildkite Plugin](https://github.com/franklin-ross/aws-restore-role-buildkite-plugin) before the wiz plugin.
+If you are using the [AWS Assume Role Plugin](https://github.com/cultureamp/aws-assume-role-buildkite-plugin), you might have trouble getting your secret key from `aws secretsmanager` if the role you assumed doesn't have the necessary access rights. To restore your role, you can use the [AWS Restore Role Buildkite Plugin](https://github.com/franklin-ross/aws-restore-role-buildkite-plugin) before the wiz plugin.
+
+```yml
+...
+  plugins:
+      - franklin-ross/aws-restore-role#HEAD
+      - blstrco/wiz#v1.0.1:
+...
+```
+
+### IaC (Infrastructure-as-Code) Cloudformation Scanning
+
+To avoid adding build time overhead, you can add IaC scanning to your `cdk diff` step. You will need to mount/export the `cdk.out` folder and pass its path to the plugin. The plugin will then scan each Cloudformation stack in the folder and create a buildkite annotation with the results.
+
+```yml
+steps:
+  - command: ls
+    env:
+    - WIZ_API_ID: "<your-id-goes-here>"
+    plugins:
+      - docker-compose#v4.16.0:
+        ...
+        # to get the output of CDK diff, mount the volume in cdk diff stage
+        - volumes:
+          - './infrastructure/cdk.out:/app/infrastructure/cdk.out'
+        ...
+      - blstrco/wiz#v1.0.1:
+          scan-type: 'iac'
+          image-address: "infrastructure/cdk.out"
+```
 
 ## Configuration
 
-### `image` (Optional, string)
+### `scan-type` (Required, string) : 'docker | iac'
+The scan type can be either docker or iac
 
-The path to image file, if `scan-type` is `image`
+### `image-address` (Optional, string)
+
+The path to image file, if the `scan-type` is `docker`
+
+### `path` (Optional, string)
+
+The path to `cdk.out` folder containing CloudFormation stack(s), if the `scan-type` is `iac`
 
 ## Developing
 


### PR DESCRIPTION
Migrate all the examples and instructions on using the plugin from notion to repository markdown.