### PR TITLE
fix: do not fail builds when we can't query secretsmanager

### DIFF
--- a/hooks/post-command
+++ b/hooks/post-command
@@ -26,6 +26,11 @@ setupWiz() {
     echo "Setting up and authenticating wiz"
     mkdir -p "$WIZ_DIR"
     WIZ_API_SECRET=$(aws secretsmanager get-secret-value --secret-id global/buildkite/wiz-api-secret --query "SecretString" --output text)
+    if [[ -z "${WIZ_API_SECRET}" ]]; then
+        echo "Error querying Wiz credentials :("
+        # why exit 0? because we don't want this to fail the build
+        exit 0
+    fi
     docker run \
         --rm -it \
         --mount type=bind,src="$WIZ_DIR",dst=/cli \


### PR DESCRIPTION
The secrets manager can sometimes fail, due to wrong role, region or a set of missing environment variables.

While we try to make it more resilient and reliable, we want to make sure we don't fail or block builds due to failures in wiz authentication.

Part of CYBER-380