### PR TITLE
feat: disable checks for hotfixes

### DIFF
--- a/hooks/post-command
+++ b/hooks/post-command
@@ -24,6 +24,12 @@ fi
 #TODO move this to agent-startup so all agents have wiz setup to save time, possibly directly as cli
 setupWiz() {
     echo "Setting up and authenticating wiz"
+    # check if this is an incident, this is when we have hotfix in the build message
+    # TODO make this configurable
+    if [[ "$BUILDKITE_MESSAGE" =~ ^hotfix.* ]]; then
+        echo "Check disabled for hotfixes. This is reserved for incident responses only, please use it with caution"
+        exit 0
+    fi
     mkdir -p "$WIZ_DIR"
     WIZ_API_SECRET=$(aws secretsmanager get-secret-value --secret-id global/buildkite/wiz-api-secret --query "SecretString" --output text)
     docker run \


### PR DESCRIPTION
We want to be able to disable the security scans for hotfixes during incident responses. This will be extremely important as we are rolling the plugin en masse.

Resolves CYBER-383