### PR TITLE
feat: use `mount` scan driver to improve scan times

### DIFF
--- a/hooks/post-command
+++ b/hooks/post-command
@@ -79,7 +79,7 @@ dockerImageScan() {
         --mount type=bind,src=/var/run/docker.sock,dst=/var/run/docker.sock \
         wiziocli.azurecr.io/wizcli:latest-amd64 \
         docker scan --image "$IMAGE" \
-        --driver mount \
+        --driver mountWithLayers \
         --policy-hits-only \
         -f human \
         -o /scan/docker-scan-result,human,true

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -76,9 +76,10 @@ dockerImageScan() {
         --rm -it \
         --mount type=bind,src="$WIZ_DIR",dst=/cli,readonly \
         --mount type=bind,src="$PWD",dst=/scan \
-        --mount type=bind,src=/var/run/docker.sock,dst=/var/run/docker.sock,readonly \
+        --mount type=bind,src=/var/run/docker.sock,dst=/var/run/docker.sock \
         wiziocli.azurecr.io/wizcli:latest-amd64 \
         docker scan --image "$IMAGE" \
+        --driver mount \
         --policy-hits-only \
         -f human \
         -o /scan/docker-scan-result,human,true

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -68,7 +68,6 @@ EOF
 }
 
 dockerImageScan() {
-    # TODO check feasibility of mount/mountWithLayers
     IMAGE="${BUILDKITE_PLUGIN_WIZ_IMAGE_ADDRESS:-}"
     # make sure local docker has the image
     docker pull "$IMAGE"

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -90,7 +90,9 @@ dockerImageScan() {
     # buildkite-agent artifact upload docker-scan-result --log-level info
     case $exit_code in
     0)
-        buildAnnotation "docker" "$image_name" true "$PWD/docker-scan-result" | buildkite-agent annotate --append --style 'success' --context 'ctx-wiz-docker-success'
+        if [[ -n "${BUILDKITE_PLUGIN_WIZ_ANNOTATE_SUCCESS}" ]]; then 
+            buildAnnotation "docker" "$image_name" true "$PWD/docker-scan-result" | buildkite-agent annotate --append --style 'success' --context 'ctx-wiz-docker-success'
+        fi
         exit 0
         ;;
     *)
@@ -116,7 +118,9 @@ iacScan() {
     exit_code="$?"
     case $exit_code in
     0)
-        buildAnnotation "iac" "$BUILDKITE_LABEL" true "$PWD/result/output" | buildkite-agent annotate --append --context 'ctx-wiz-iac-success' --style 'success'
+        if [[ -n "${BUILDKITE_PLUGIN_WIZ_ANNOTATE_SUCCESS}" ]]; then 
+            buildAnnotation "iac" "$BUILDKITE_LABEL" true "$PWD/result/output" | buildkite-agent annotate --append --context 'ctx-wiz-iac-success' --style 'success'
+        fi
         ;;
     *)
         buildAnnotation "iac" "$BUILDKITE_LABEL" false "$PWD/result/output" | buildkite-agent annotate --append --context 'ctx-wiz-iac-warning' --style 'warning'

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -74,8 +74,10 @@ dockerImageScan() {
     docker pull "$IMAGE"
     docker run \
         --rm -it \
+        --cap-add SYS_ADMIN \
         --mount type=bind,src="$WIZ_DIR",dst=/cli,readonly \
         --mount type=bind,src="$PWD",dst=/scan \
+        --mount type=bind,src=/var/lib/docker,dst=/var/lib/docker \
         --mount type=bind,src=/var/run/docker.sock,dst=/var/run/docker.sock \
         wiziocli.azurecr.io/wizcli:latest-amd64 \
         docker scan --image "$IMAGE" \

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -81,7 +81,7 @@ dockerImageScan() {
         --mount type=bind,src=/var/run/docker.sock,dst=/var/run/docker.sock \
         wiziocli.azurecr.io/wizcli:latest-amd64 \
         docker scan --image "$IMAGE" \
-        --driver mountWithLayers \
+        --driver mount \
         --policy-hits-only \
         -f human \
         -o /scan/docker-scan-result,human,true

--- a/plugin.yml
+++ b/plugin.yml
@@ -14,4 +14,6 @@ configuration:
       enum:
         - docker
         - iac
+    annotate-success:
+      type: boolean
   additionalProperties: false


### PR DESCRIPTION
As recommended by Wiz - seeing huge improvements in scan time https://buildkite.com/linktree/monolith/builds/48748#018f800c-a613-4ba0-9424-bff874834766

Also introduced an `annotate-success` prop to allow us to switch off successful notifications by default and reduce noise