### PR TITLE
chore: allow unbound variables

### DIFF
--- a/hooks/post-command
+++ b/hooks/post-command
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -uo pipefail
+set -o pipefail
 
 WIZ_DIR="$HOME/.wiz"
 SCAN_TYPE="${BUILDKITE_PLUGIN_WIZ_SCAN_TYPE:-}"


### PR DESCRIPTION
Required as we're now allowing the optional value `annotate-success`