### PR TITLE
feat: migrate docker image scanning to WizCLI v1

### DIFF
--- a/hooks/post-command
+++ b/hooks/post-command
@@ -120,7 +120,8 @@ iac)
     dirScan
     ;;
 docker)
-    setupWiz
-    dockerImageScan
+    source "${BASEDIR}/lib/wizcli.sh"
+    setupWizCli
+    dockerScan
     ;;
 esac

--- a/lib/wizcli.sh
+++ b/lib/wizcli.sh
@@ -71,6 +71,59 @@ buildScanTags() {
     printf '%s\n' "${tags[@]}"
 }
 
+dockerScan() {
+    IMAGE="${BUILDKITE_PLUGIN_WIZ_IMAGE_ADDRESS:-}"
+    SCAN_NAME="$(buildScanName)"
+    TAG_ARGS=()
+
+    if [[ -z "${IMAGE}" ]]; then
+        echo "Missing image address, docker scans require an address to pull the image"
+        return 1
+    fi
+
+    while IFS= read -r tag; do
+        TAG_ARGS+=(--tags "${tag}")
+    done < <(buildScanTags)
+
+    # Make sure local docker has the image
+    echo "--- :wiz: Pulling image ${IMAGE}"
+    docker pull "$IMAGE"
+
+    echo "--- :wiz: Running Wiz CLI docker scan on ${IMAGE}"
+    docker run \
+        --rm \
+        --mount type=bind,src=/var/run/docker.sock,dst=/var/run/docker.sock \
+        --mount type=bind,src="$PWD",dst=/scan \
+        "$WIZCLI_LOCAL_TAG" \
+        scan docker "$IMAGE" \
+        --name "$SCAN_NAME" \
+        --client-id "$WIZ_CLIENT_ID" \
+        --client-secret "$WIZ_CLIENT_SECRET" \
+        --by-policy-hits=BLOCK \
+        --stdout=human \
+        --human-output-file=/scan/docker-scan-result \
+        "${TAG_ARGS[@]}"
+    exit_code="$?"
+    image_name=$(echo "$IMAGE" | cut -d "/" -f 2)
+
+    if [[ "${WIZ_ANNOTATIONS:-false}" == "false" ]]; then
+        return 0
+    fi
+
+    case $exit_code in
+    0)
+        if [[ -n "${BUILDKITE_PLUGIN_WIZ_ANNOTATE_SUCCESS:-}" ]]; then
+            buildAnnotation "docker" "$image_name" true "$PWD/docker-scan-result" | buildkite-agent annotate --append --style 'success' --context 'ctx-wiz-docker-success'
+        fi
+        return 0
+        ;;
+    *)
+        buildAnnotation "docker" "$image_name" false "$PWD/docker-scan-result" | buildkite-agent annotate --append --context 'ctx-wiz-docker-warning' --style 'warning'
+        return 0
+        ;;
+    esac
+}
+
 dirScan() {
     SCAN_PATH="${BUILDKITE_PLUGIN_WIZ_PATH:-}"
     SCAN_NAME="$(buildScanName)"


### PR DESCRIPTION
# feat: migrate docker image scanning to WizCLI v1

## Summary

Migrates docker image scanning from WizCLI 0.X to v1, matching the pattern already used for IaC directory scans since v1.3.1.

**Problem:** Docker scans using `wiziocli.azurecr.io/wizcli:latest-amd64` (0.X) with `--driver mount` fail in CI with:
```
error creating new layer store from options, driver [overlayfs]: driver not supported
error creating containerd client: failed to dial "/run/containerd/containerd.sock": context deadline exceeded
```
WizCLI 0.X also reaches End of Support on April 15, 2026.

**Fix:** Adds a `dockerScan()` function to `lib/wizcli.sh` that uses WizCLI v1 (`public-registry.wiz.io/wiz-app/wizcli:1`) with Docker socket access instead of the overlayfs/containerd-dependent `--driver mount`. Routes the `docker` scan type through `setupWizCli` + `dockerScan` instead of the old `setupWiz` + `dockerImageScan`.

## Review & Testing Checklist for Human

- [ ] **Verify WizCLI v1 `scan docker` command syntax** — The new function uses `scan docker "$IMAGE"` with flags like `--by-policy-hits=BLOCK`, `--stdout=human`, `--human-output-file`. These are modeled after the existing `scan dir` pattern but **have not been validated against v1 docker scan docs**. Please confirm these flags are correct for `wizcli scan docker`.
- [ ] **Verify credentials secret works for docker scans** — `setupWizCli` reads from `global/buildkite/wiz-cli-credentials` (JSON with `client_id`/`client_secret`), while the old `setupWiz` used `global/buildkite/wiz-api-details`/`wiz-api-secret`. Confirm the v1 credentials are provisioned for all pipelines that run docker scans.
- [ ] **Test with a real Buildkite build** — This can only be verified by running a pipeline that triggers a docker scan (e.g., monolith's build-images step). Run one build and confirm the scan completes successfully.
- [ ] **Confirm `buildAnnotation` is accessible** — `dockerScan()` calls `buildAnnotation()` which is defined in `hooks/post-command`. Since `wizcli.sh` is sourced from `post-command`, this should work, but worth confirming annotations render correctly.
- [ ] **Consider cleaning up dead code** — The old `setupWiz()` and `dockerImageScan()` functions in `hooks/post-command` are now unused. They could be removed in a follow-up to avoid confusion.

### Test Plan
1. Trigger a Buildkite build in a pipeline that runs Wiz docker scans (e.g., `blstrco/linktr.ee-monolith` build-images)
2. Verify the scan completes without overlayfs/containerd errors
3. Verify scan results are reported correctly (annotations, policy violations, etc.)
4. If the scan fails with "command not found" or syntax errors, review WizCLI v1 docs and adjust flags

### Notes
- This aligns docker scanning with the IaC scanning migration done in v1.3.1/v1.4.0
- Also adds scan naming, Buildkite URL tagging, and GitHub PR URL tagging to docker scans (parity with dir scans)
- The old 0.X approach is left in place (dead code) to minimize risk; can be removed in a follow-up

---

Link to Devin session: https://app.devin.ai/sessions/98cdfbb27cb343078af1cefa6bddec96  
Requested by: @Tolsee